### PR TITLE
Added inline specifier to str function

### DIFF
--- a/include/srilakshmikanthanp/ANSI.hpp
+++ b/include/srilakshmikanthanp/ANSI.hpp
@@ -34,7 +34,7 @@ namespace srilakshmikanthanp
         /**
          * @brief ansi to string
          */
-        std::string str(std::ostream &(*manip)(std::ostream &))
+        inline std::string str(std::ostream &(*manip)(std::ostream &))
         {
             std::ostringstream stream("");
             stream << manip;


### PR DESCRIPTION
Added inline specifier to std::string str(std::ostream &(*manip)(std::ostream &)) so there is no odr violation when ANSI.hpp is included in multiple translation units.